### PR TITLE
Replace license classifier with SPDX identifier per PEP 639

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         'Development Status :: 4 - Beta',
         'Environment :: Plugins',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Hi  André!
First of all, I would like to congratulate you on the project.

I am a Debian maintainer and I recently learned about friendly and I am willing to package it for our distribution.

But first I need to package:
friendly-traceback
friendly_styles

friendly-traceback is already in Debian. friendly_styles is under review.

Here is an update on how to declare the License based on PEP639.

Kind regards,

I published it taking into account

## Summary by Sourcery

Enhancements:
- Remove the 'License :: OSI Approved :: MIT License' classifier from setup.py to adopt SPDX-based licensing